### PR TITLE
Fix publishing warnings, use python -m build to correctly create sdist version from pyproject.toml metadata

### DIFF
--- a/.github/workflows/publish-sdist-wheels.yml
+++ b/.github/workflows/publish-sdist-wheels.yml
@@ -105,4 +105,4 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_PASSWORD }}
-          packages_dir: dist/
+          packages-dir: dist/

--- a/.github/workflows/publish-sdist-wheels.yml
+++ b/.github/workflows/publish-sdist-wheels.yml
@@ -4,7 +4,7 @@ on: [pull_request, push]
 env:
   CIBW_BUILD_VERBOSITY: 3
   CIBW_BUILD: 'cp3*'
-  CIBW_SKIP: 'cp35-* cp36-* cp37-* *-musllinux_* *-manylinux_i686'
+  CIBW_SKIP: 'cp36-* cp37-* *-musllinux_* *-manylinux_i686'
   CIBW_TEST_REQUIRES: pytest trimesh numpy
   CIBW_TEST_COMMAND: "pytest {project}/tests"
 

--- a/ci/python_build_sdist.sh
+++ b/ci/python_build_sdist.sh
@@ -18,13 +18,13 @@ set +u  # ignore missing variables in activation script
 source "$BIN/activate"
 set -u
 
-"$BIN/pip" install -U pipx
+"$BIN/pip" install --upgrade build twine
 
 # Build distribution
-"$BIN/pipx" run build --sdist
+"$BIN/python" -m build
 
 # Check metadata
-"$BIN/pipx" run twine check dist/*
+"$BIN/twine" check dist/*
 
 
 ls -al dist

--- a/ci/python_build_sdist.sh
+++ b/ci/python_build_sdist.sh
@@ -18,8 +18,14 @@ set +u  # ignore missing variables in activation script
 source "$BIN/activate"
 set -u
 
-"$BIN/pip" install -U setuptools pip
-"$BIN/python" setup.py sdist
+"$BIN/pip" install -U pipx
+
+# Build distribution
+"$BIN/pipx" run build --sdist
+
+# Check metadata
+"$BIN/pipx" run twine check dist/*
+
 
 ls -al dist
 


### PR DESCRIPTION
setup.py sdist creates a 0.0.0 version. Use pipx build to take pyproject.toml into account.

It seems the wheels were uploaded but the sdist was rejected by pypi due to the 0.0.0 version.