### PR TITLE
Let automatic discovery handle the repo layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,7 @@ Issues = "https://github.com/BlueBrain/cgal-pybind/issues"
 Tracker = "https://github.com/BlueBrain/cgal-pybind/issues"
 
 [tool.setuptools.packages.find]
-include = ["cgal_pybind"]
-namespaces = false
+where = ["src/cgal_pybind"]
 
 [tool.scikit-build]
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,6 @@ Repository = "https://github.com/BlueBrain/cgal-pybind"
 Issues = "https://github.com/BlueBrain/cgal-pybind/issues"
 Tracker = "https://github.com/BlueBrain/cgal-pybind/issues"
 
-[tool.setuptools.packages.find]
-where = ["src/cgal_pybind"]
-
 [tool.scikit-build]
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 


### PR DESCRIPTION
Current configuration was wrong as it hinted a flat-layout and was ignored. Given that automatic discovery handles the src layout according to:
https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#src-layout
there is no need to explicitly specify the src location.